### PR TITLE
extend ecrf exporter config to abbreviate visits in colnames

### DIFF
--- a/bulk_processor/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/settings.debug.yml
+++ b/bulk_processor/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/settings.debug.yml
@@ -42,6 +42,9 @@ ecrfrevision_abbreviate_opts:
 
 ecrfname_abbreviate_opts:
   word_count_limit: 0
+
+visit_abbreviate_opts:
+  word_count_limit: 0
   
 section_abbreviate_opts:
   word_count_limit: 0

--- a/bulk_processor/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/settings.yml
+++ b/bulk_processor/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/settings.yml
@@ -41,6 +41,9 @@ ecrfrevision_abbreviate_opts:
 
 ecrfname_abbreviate_opts:
   word_count_limit: 0
+
+visit_abbreviate_opts:
+  word_count_limit: 0
   
 section_abbreviate_opts:
   word_count_limit: 0


### PR DESCRIPTION
statistic packages such as SPSS have the limitation of 64chars for parameter (column) names.

the ecrf exporter therfore provides a (optionial) configurable abbreviation technique to build human readable colnames including ecrf name, section, field name etc. it should allow to keep colnames below 64chars, without collisions.

for adding the visit dimension to the eCRF data model, the col naming now need to be extended to also include the visit.